### PR TITLE
ZGW-3403: conf: Align param ZipAssociationLimit to convention, fixup

### DIFF
--- a/contiki/platform/linux/parse_config.c
+++ b/contiki/platform/linux/parse_config.c
@@ -423,12 +423,12 @@ void ConfigInit()
     }
 
     cfg.single_classic_temp_association = atoi(
-      config_get_val("single_classic_temp_association", "0"));
+      config_get_val("ZipAssociationLimit", "0"));
 
     if ((0 != cfg.single_classic_temp_association) &&
       (1 != cfg.single_classic_temp_association)) {
       WRN_PRINTF("Wrong configuration value for "
-                 "\"single_classic_temp_association\" (%d). Ignoring",
+                 "\"ZipAssociationLimit\" (%d). Ignoring",
                  cfg.single_classic_temp_association);
 
       cfg.single_classic_temp_association = 0;


### PR DESCRIPTION
This align to other params.

For the record the change has been tested on a US device.

Relate-to: https://github.com/SiliconLabs/zipgateway/pull/21
Relate-to: https://github.com/SiliconLabs/zipgateway/pull/20